### PR TITLE
Add portfolio field to CF Chat and enhance variable replacement

### DIFF
--- a/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.json
@@ -5,6 +5,7 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "portfolio",
   "security",
   "title",
   "column_break_zqji",
@@ -26,7 +27,7 @@
    "in_standard_filter": 1,
    "label": "Security",
    "options": "CF Security",
-   "reqd": 1,
+   "read_only": 1,
    "search_index": 1
   },
   {
@@ -55,6 +56,16 @@
    "label": "Model",
    "options": "deepseek-chat\ndeepseek-reasoner",
    "reqd": 1
+  },
+  {
+   "fieldname": "portfolio",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Portfolio",
+   "options": "CF Portfolio",
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
@@ -65,7 +76,7 @@
    "link_fieldname": "chat"
   }
  ],
- "modified": "2025-05-27 11:16:44.818288",
+ "modified": "2025-05-27 15:14:05.145108",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Chat",

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.py
@@ -6,4 +6,10 @@ from frappe.model.document import Document
 
 
 class CFChat(Document):
-	pass
+    def on_trash(self):
+        """Delete all related chat messages before deleting the chat"""
+        # Delete all cf_chat_messages linked to this chat
+        frappe.db.delete("CF Chat Message", {"chat": self.name})
+        
+        # Commit the deletion of child records
+        frappe.db.commit()

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.py
@@ -145,7 +145,7 @@ class CFChatMessage(Document):
 					if securities:
 						# If multiple securities, return them separated by newlines
 						if len(securities) > 1:
-							field_value = "\n".join(str(getattr(sec, variable_name, "")) for sec in securities)
+							field_value = "\n\n".join(str(getattr(sec, variable_name, "")) for sec in securities)
 					else:
 						field_value = None
 				else:

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.py
@@ -97,6 +97,7 @@ class CFChatMessage(Document):
 			return 0
 		
 		chat = frappe.get_doc("CF Chat", self.chat)
+		portfolio = frappe.get_doc("CF Portfolio", chat.portfolio)
 		security = frappe.get_doc("CF Security", chat.security)
 		settings = frappe.get_single("CF Settings")
 		client = OpenAI(api_key=settings.get_password('open_ai_api_key'), base_url=settings.open_ai_url)
@@ -123,7 +124,12 @@ class CFChatMessage(Document):
 			variable_name = match.group(1)
 			try:
 				# Get the actual field value from the document
-				field_value = getattr(security, variable_name, None)
+				if security:
+					field_value = getattr(security, variable_name, None)
+				elif portfolio:
+					field_value = getattr(portfolio, variable_name, None)
+				else:
+					field_value = None
 				if field_value is not None:
 					return str(field_value)
 				else:

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.py
@@ -97,8 +97,12 @@ class CFChatMessage(Document):
 			return 0
 		
 		chat = frappe.get_doc("CF Chat", self.chat)
-		portfolio = frappe.get_doc("CF Portfolio", chat.portfolio)
-		security = frappe.get_doc("CF Security", chat.security)
+		portfolio = None
+		if chat.portfolio:
+			portfolio = frappe.get_doc("CF Portfolio", chat.portfolio)
+		security = None
+		if chat.security:
+			security = frappe.get_doc("CF Security", chat.security)
 		settings = frappe.get_single("CF Settings")
 		client = OpenAI(api_key=settings.get_password('open_ai_api_key'), base_url=settings.open_ai_url)
 

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.py
@@ -131,7 +131,23 @@ class CFChatMessage(Document):
 				if security:
 					field_value = getattr(security, variable_name, None)
 				elif portfolio:
-					field_value = getattr(portfolio, variable_name, None)
+					securities = frappe.get_all(
+						"CF Portfolio Holding",
+						filters={"portfolio": portfolio.name},
+						fields=["security"]
+					)
+					# Get the actual security documents
+					security_docs = []
+					for holding in securities:
+						sec_doc = frappe.get_doc("CF Security", holding.security)
+						security_docs.append(sec_doc)
+					securities = security_docs
+					if securities:
+						# If multiple securities, return them separated by newlines
+						if len(securities) > 1:
+							field_value = "\n".join(str(getattr(sec, variable_name, "")) for sec in securities)
+					else:
+						field_value = None
 				else:
 					field_value = None
 				if field_value is not None:

--- a/cognitive_folio/cognitive_folio/doctype/cf_portfolio/cf_portfolio.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_portfolio/cf_portfolio.json
@@ -254,9 +254,13 @@
   {
    "link_doctype": "CF Dividend",
    "link_fieldname": "portfolio"
+  },
+  {
+   "link_doctype": "CF Chat",
+   "link_fieldname": "portfolio"
   }
  ],
- "modified": "2025-05-22 06:29:47.125694",
+ "modified": "2025-05-27 15:16:22.099304",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Portfolio",


### PR DESCRIPTION
Introduce a portfolio field in CF Chat, linking it to CF Portfolio. Enhance variable replacement logic to support multiple securities from portfolio holdings and ensure fetching occurs only if they exist. Update handling to separate multiple securities with double newlines.