### PR TITLE
Add CF Prompt DocType with copy button functionality

### DIFF
--- a/cognitive_folio/cognitive_folio/doctype/cf_prompt/cf_prompt.js
+++ b/cognitive_folio/cognitive_folio/doctype/cf_prompt/cf_prompt.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, KAINOTOMO PH LTD and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("CF Prompt", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/cognitive_folio/cognitive_folio/doctype/cf_prompt/cf_prompt.js
+++ b/cognitive_folio/cognitive_folio/doctype/cf_prompt/cf_prompt.js
@@ -1,8 +1,90 @@
 // Copyright (c) 2025, KAINOTOMO PH LTD and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("CF Prompt", {
-// 	refresh(frm) {
+frappe.ui.form.on("CF Prompt", {
+    refresh(frm) {
+        // Add copy buttons for multiple fields only for existing documents
+        if (!frm.doc.__islocal) {
+            const fieldsWithCopyButtons = ['content'];
+            fieldsWithCopyButtons.forEach(fieldName => {
+                addCopyButtonToField(frm, fieldName);
+            });
+        }
+    },
+});
 
-// 	},
-// });
+// Add this helper function after the frappe.ui.form.on block
+function addCopyButtonToField(frm, fieldName) {
+    if (frm.doc[fieldName]) {
+        // Get the field wrapper
+        const field = frm.get_field(fieldName);
+        if (field && field.$wrapper) {
+            // Remove any existing copy button first
+            field.$wrapper.find('.copy-btn').remove();
+            
+            // Create a small copy button
+            const copyBtn = $(`
+                <button type="button" class="btn btn-xs btn-default copy-btn" 
+                        style="margin-left: 5px; padding: 2px 8px; font-size: 11px;">
+                    <i class="fa fa-copy"></i> Copy
+                </button>
+            `);
+            
+            // Add click handler
+            copyBtn.on('click', function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                
+                // Use the modern Clipboard API
+                if (navigator.clipboard && window.isSecureContext) {
+                    navigator.clipboard.writeText(frm.doc[fieldName]).then(function() {
+                        frappe.show_alert({
+                            message: __(`${getFieldDisplayName(fieldName)} data copied to clipboard`),
+                            indicator: 'green'
+                        });
+                    }).catch(function(err) {
+                        console.error('Failed to copy: ', err);
+                        frappe.msgprint({
+                            title: __('Copy Error'),
+                            indicator: 'red',
+                            message: __(`Failed to copy ${getFieldDisplayName(fieldName)} data to clipboard`)
+                        });
+                    });
+                } else {
+                    // Fallback for older browsers or non-secure contexts
+                    try {
+                        const textArea = document.createElement('textarea');
+                        textArea.value = frm.doc[fieldName];
+                        textArea.style.position = 'fixed';
+                        textArea.style.opacity = '0';
+                        document.body.appendChild(textArea);
+                        textArea.focus();
+                        textArea.select();
+                        
+                        const successful = document.execCommand('copy');
+                        document.body.removeChild(textArea);
+                        
+                        if (successful) {
+                            frappe.show_alert({
+                                message: __(`${getFieldDisplayName(fieldName)} data copied to clipboard`),
+                                indicator: 'green'
+                            });
+                        } else {
+                            throw new Error('Copy command failed');
+                        }
+                    } catch (err) {
+                        console.error('Fallback copy failed: ', err);
+                        frappe.msgprint({
+                            title: __('Copy Error'),
+                            indicator: 'red',
+                            message: __(`Failed to copy ${getFieldDisplayName(fieldName)} data to clipboard`)
+                        });
+                    }
+                }
+            });
+            
+            // Append the button to the field's label area
+            field.$wrapper.find('.control-label').append(copyBtn);
+        }
+    }
+}

--- a/cognitive_folio/cognitive_folio/doctype/cf_prompt/cf_prompt.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_prompt/cf_prompt.json
@@ -1,0 +1,53 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-05-28 10:25:28.728939",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "content"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "fieldname": "content",
+   "fieldtype": "Markdown Editor",
+   "label": "Content"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-05-28 10:26:12.224026",
+ "modified_by": "Administrator",
+ "module": "Cognitive Folio",
+ "name": "CF Prompt",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title"
+}

--- a/cognitive_folio/cognitive_folio/doctype/cf_prompt/cf_prompt.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_prompt/cf_prompt.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, KAINOTOMO PH LTD and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class CFPrompt(Document):
+	pass

--- a/cognitive_folio/cognitive_folio/doctype/cf_prompt/test_cf_prompt.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_prompt/test_cf_prompt.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, KAINOTOMO PH LTD and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestCFPrompt(FrappeTestCase):
+	pass


### PR DESCRIPTION
Introduce a new DocType for CF Prompt with title and content fields. Implement a copy button for the content field to enhance user experience.