### PR TITLE
Add 'Amend' functionality and support for duplicated chat messages

### DIFF
--- a/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.js
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.js
@@ -9,6 +9,21 @@ frappe.ui.form.on("CF Chat", {
                 frappe.new_doc('CF Chat Message', {
                     chat: frm.doc.name
                 });
+            }).addClass('btn-primary');
+        }
+
+        // Show Amend button if not new and not already amended
+        if (!frm.is_new() && !frm.doc.amended_from) {
+            frm.add_custom_button(__('Amend'), function() {
+                frappe.call({
+                    method: "cognitive_folio.cognitive_folio.doctype.cf_chat.cf_chat.amend_cf_chat",
+                    args: { name: frm.doc.name },
+                    callback: function(r) {
+                        if (r.message) {
+                            frappe.set_route("Form", "CF Chat", r.message);
+                        }
+                    }
+                });
             });
         }
 

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.json
@@ -11,6 +11,7 @@
   "column_break_zqji",
   "model",
   "system_prompt",
+  "duplicated_from",
   "messages_section",
   "messages"
  ],
@@ -66,6 +67,15 @@
    "options": "CF Portfolio",
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "duplicated_from",
+   "fieldtype": "Link",
+   "label": "Duplicated From",
+   "no_copy": 1,
+   "options": "CF Chat",
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -76,7 +86,7 @@
    "link_fieldname": "chat"
   }
  ],
- "modified": "2025-05-27 15:14:05.145108",
+ "modified": "2025-05-29 07:07:34.847389",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Chat",

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.py
@@ -13,3 +13,30 @@ class CFChat(Document):
         
         # Commit the deletion of child records
         frappe.db.commit()
+
+    def after_insert(self):
+        """If duplicated_from then copy the chat messages from the original chat"""
+        if self.duplicated_from:
+            # Fetch messages from the cf_chat_message doctype
+            messages = frappe.get_all(
+                "CF Chat Message",
+                filters={"chat": self.duplicated_from},
+                fields=["name"],
+                order_by="creation asc"
+            )
+            for message in messages:
+                old_message = frappe.get_doc("CF Chat Message", message.name)
+                new_message = frappe.copy_doc(old_message)
+                new_message.chat = self.name
+                new_message.flags.ignore_before_save = True
+                new_message.insert()
+
+@frappe.whitelist()
+def amend_cf_chat(name):
+    doc = frappe.get_doc("CF Chat", name)
+    doc.status = "Cancelled"
+    new_doc = frappe.copy_doc(doc)
+    new_doc.duplicated_from = doc.name
+    new_doc.title = f"{doc.title} (Amended)"
+    new_doc.insert()
+    return new_doc.name

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.py
@@ -12,6 +12,10 @@ class CFChatMessage(Document):
 				self.system_prompt = chat.system_prompt
 
 	def before_save(self):
+		# Skip processing if this is a duplicated message
+		if getattr(self.flags, 'ignore_before_save', False):
+			return
+			
 		self.status = "Processing"
 		
 		self.response = "Processing your request..."


### PR DESCRIPTION
Introduce an 'Amend' button for existing chat entries and implement logic to duplicate chat messages from an original chat when creating a new entry.