### PR TITLE
Refactor response fields and sanitize news data formatting

### DIFF
--- a/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.json
@@ -38,11 +38,9 @@
   },
   {
    "fieldname": "response",
-   "fieldtype": "Long Text",
-   "hidden": 1,
+   "fieldtype": "Markdown Editor",
    "label": "Response",
-   "no_copy": 1,
-   "read_only": 1
+   "no_copy": 1
   },
   {
    "fieldname": "tokens",
@@ -80,6 +78,7 @@
   {
    "fieldname": "response_html",
    "fieldtype": "Long Text",
+   "hidden": 1,
    "label": "Response Html",
    "no_copy": 1,
    "read_only": 1
@@ -102,7 +101,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-30 06:40:36.554398",
+ "modified": "2025-05-30 08:23:24.133023",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Chat Message",

--- a/cognitive_folio/cognitive_folio/doctype/cf_portfolio_holding/cf_portfolio_holding.js
+++ b/cognitive_folio/cognitive_folio/doctype/cf_portfolio_holding/cf_portfolio_holding.js
@@ -147,8 +147,8 @@ function formatNewsData(newsData) {
         
         const content = item.content;
         const canonicalUrl = content.canonicalUrl && content.canonicalUrl.url;
-        const title = content.title || 'No title';
-        const summary = content.summary || 'No summary available';
+        const title = content.title?.replace(/['"]/g, "") || "No title";
+        const summary = content.summary?.replace(/['"]/g, "") || "No summary available";
         const pubDate = content.pubDate || '';
         
         if (!canonicalUrl) continue;

--- a/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.js
+++ b/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.js
@@ -407,8 +407,8 @@ function formatNewsData(newsData) {
         
         const content = item.content;
         const canonicalUrl = content.canonicalUrl && content.canonicalUrl.url;
-        const title = content.title || 'No title';
-        const summary = content.summary || 'No summary available';
+        const title = content.title?.replace(/['"]/g, "") || "No title";
+        const summary = content.summary?.replace(/['"]/g, "") || "No summary available";
         const pubDate = content.pubDate || '';
         
         if (!canonicalUrl) continue;


### PR DESCRIPTION
Sanitize title and summary fields in the `formatNewsData` function for improved HTML formatting. Change the response field type to a Markdown Editor and update the visibility of the response_html field.