### PR TITLE
Update CF Portfolio Holding and CF Security with new default view and shortcuts

### DIFF
--- a/cognitive_folio/cognitive_folio/doctype/cf_portfolio_holding/cf_portfolio_holding.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_portfolio_holding/cf_portfolio_holding.json
@@ -3,6 +3,7 @@
  "allow_import": 1,
  "autoname": "format:CFPH-{####}",
  "creation": "2025-05-14 11:00:00",
+ "default_view": "Report",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -402,7 +403,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-30 11:54:03.205560",
+ "modified": "2025-05-30 18:29:25.129863",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Portfolio Holding",

--- a/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.json
@@ -4,6 +4,7 @@
  "allow_rename": 1,
  "autoname": "field:symbol",
  "creation": "2025-05-14 10:00:00",
+ "default_view": "Report",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -399,7 +400,7 @@
    "link_fieldname": "security"
   }
  ],
- "modified": "2025-05-30 10:28:00.138034",
+ "modified": "2025-05-30 18:28:51.396869",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Security",
@@ -438,7 +439,9 @@
  ],
  "row_format": "Dynamic",
  "search_fields": "security_name,symbol,isin,security_type,sector",
+ "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "security_name"
 }

--- a/cognitive_folio/cognitive_folio/workspace/cognitive_folio/cognitive_folio.json
+++ b/cognitive_folio/cognitive_folio/workspace/cognitive_folio/cognitive_folio.json
@@ -13,7 +13,7 @@
  "is_hidden": 0,
  "label": "Cognitive Folio",
  "links": [],
- "modified": "2025-05-28 19:03:58.584500",
+ "modified": "2025-05-30 18:30:13.675927",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "Cognitive Folio",
@@ -25,6 +25,22 @@
  "roles": [],
  "sequence_id": 1.0,
  "shortcuts": [
+  {
+   "color": "Blue",
+   "doc_view": "Report Builder",
+   "label": "Securities",
+   "link_to": "CF Security",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Blue",
+   "doc_view": "Report Builder",
+   "label": "Holdings",
+   "link_to": "CF Portfolio Holding",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
   {
    "color": "Grey",
    "doc_view": "List",
@@ -47,22 +63,6 @@
    "label": "Portfolios",
    "link_to": "CF Portfolio",
    "stats_filter": "[[\"CF Portfolio\",\"disabled\",\"=\",0,false]]",
-   "type": "DocType"
-  },
-  {
-   "color": "Blue",
-   "doc_view": "List",
-   "label": "Securities",
-   "link_to": "CF Security",
-   "stats_filter": "[]",
-   "type": "DocType"
-  },
-  {
-   "color": "Blue",
-   "doc_view": "List",
-   "label": "Holdings",
-   "link_to": "CF Portfolio Holding",
-   "stats_filter": "[]",
    "type": "DocType"
   },
   {


### PR DESCRIPTION
Set the default view to "Report" for CF Portfolio Holding and CF Security, and add shortcuts for easy access to these documents in the cognitive_folio.json file.