### PR TITLE
Add template_prompt field and content fetching logic across CF modules

### DIFF
--- a/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.json
@@ -8,10 +8,10 @@
   "portfolio",
   "security",
   "title",
+  "duplicated_from",
   "column_break_zqji",
   "model",
   "system_prompt",
-  "duplicated_from",
   "messages_section",
   "messages"
  ],
@@ -48,7 +48,7 @@
   {
    "allow_in_quick_entry": 1,
    "fieldname": "system_prompt",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "System Prompt"
   },
   {
@@ -86,7 +86,7 @@
    "link_fieldname": "chat"
   }
  ],
- "modified": "2025-05-29 07:07:34.847389",
+ "modified": "2025-06-01 09:41:39.148767",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Chat",

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.js
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.js
@@ -8,5 +8,20 @@ frappe.ui.form.on("CF Chat Message", {
         if (frm.doc.chat) {
             frappe.set_route('Form', 'CF Chat', frm.doc.chat);
         }
+    },
+
+    template_prompt(frm) {
+        // When template_prompt field is changed, fetch the content from CF Prompt
+        if (frm.doc.template_prompt) {
+            frappe.db.get_value('CF Prompt', frm.doc.template_prompt, 'content')
+                .then(r => {
+                    if (r.message && r.message.content) {
+                        frm.set_value('prompt', r.message.content);
+                    }
+                });
+        } else {
+            // Clear prompt if template_prompt is cleared
+            frm.set_value('prompt', '');
+        }
     }
 });

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.json
@@ -10,6 +10,7 @@
   "model",
   "status",
   "system_prompt",
+  "template_prompt",
   "section_break_nyal",
   "prompt",
   "response_html",
@@ -96,12 +97,18 @@
    "fieldname": "system_prompt",
    "fieldtype": "Data",
    "label": "System Prompt"
+  },
+  {
+   "fieldname": "template_prompt",
+   "fieldtype": "Link",
+   "label": "Template Prompt",
+   "options": "CF Prompt"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-30 18:50:05.799446",
+ "modified": "2025-06-01 07:38:32.465898",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Chat Message",

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.json
@@ -6,9 +6,9 @@
  "engine": "InnoDB",
  "field_order": [
   "chat",
+  "status",
   "column_break_cbjh",
   "model",
-  "status",
   "system_prompt",
   "template_prompt",
   "section_break_nyal",
@@ -95,7 +95,7 @@
    "fetch_from": "chat.system_prompt",
    "fetch_if_empty": 1,
    "fieldname": "system_prompt",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "System Prompt"
   },
   {
@@ -108,7 +108,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-01 07:38:32.465898",
+ "modified": "2025-06-01 09:41:27.986475",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Chat Message",

--- a/cognitive_folio/cognitive_folio/doctype/cf_portfolio/cf_portfolio.js
+++ b/cognitive_folio/cognitive_folio/doctype/cf_portfolio/cf_portfolio.js
@@ -200,5 +200,20 @@ frappe.ui.form.on("CF Portfolio", {
                 });
             }, __('Actions'));
         }
+    },
+
+    template_prompt(frm) {
+        // When template_prompt field is changed, fetch the content from CF Prompt
+        if (frm.doc.template_prompt) {
+            frappe.db.get_value('CF Prompt', frm.doc.template_prompt, 'content')
+                .then(r => {
+                    if (r.message && r.message.content) {
+                        frm.set_value('ai_prompt', r.message.content);
+                    }
+                });
+        } else {
+            // Clear prompt if template_prompt is cleared
+            frm.set_value('ai_prompt', '');
+        }
     }
 });

--- a/cognitive_folio/cognitive_folio/doctype/cf_portfolio/cf_portfolio.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_portfolio/cf_portfolio.json
@@ -37,6 +37,7 @@
   "ai_suggestion_html",
   "ai_suggestion",
   "ai_tab",
+  "template_prompt",
   "ai_prompt"
  ],
  "fields": [
@@ -227,14 +228,19 @@
   },
   {
    "fieldname": "ai_prompt",
-   "fieldtype": "Text",
-   "label": "AI Prompt",
-   "read_only": 1
+   "fieldtype": "Markdown Editor",
+   "label": "AI Prompt"
   },
   {
    "fieldname": "ai_tab",
    "fieldtype": "Tab Break",
    "label": "AI"
+  },
+  {
+   "fieldname": "template_prompt",
+   "fieldtype": "Link",
+   "label": "Template Prompt",
+   "options": "CF Prompt"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -260,7 +266,7 @@
    "link_fieldname": "portfolio"
   }
  ],
- "modified": "2025-05-30 10:28:33.852199",
+ "modified": "2025-06-01 09:44:05.402887",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Portfolio",

--- a/cognitive_folio/cognitive_folio/doctype/cf_portfolio/cf_portfolio.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_portfolio/cf_portfolio.py
@@ -431,7 +431,7 @@ def process_portfolio_ai_analysis(portfolio_name, user):
 			if not holdings:
 				raise ValueError(_('No holdings found in this portfolio'))
 			
-			prompt = settings.user_content
+			prompt = portfolio.ai_prompt or ""
 
 			# Replace ((variable)) with portfolio fields once at the end
 			def replace_portfolio_variables(match):
@@ -534,7 +534,6 @@ def process_portfolio_ai_analysis(portfolio_name, user):
 			markdown_content = safe_markdown_to_html(content)
 			
 			# Save to portfolio
-			portfolio.ai_prompt = prompt
 			portfolio.ai_suggestion = markdown_content
 			portfolio.save()
 			

--- a/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.js
+++ b/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.js
@@ -277,6 +277,21 @@ frappe.ui.form.on('CF Security', {
         } else {
             frm.set_df_property('current_price', 'read_only', 1);
         }
+    },
+
+    template_prompt(frm) {
+        // When template_prompt field is changed, fetch the content from CF Prompt
+        if (frm.doc.template_prompt) {
+            frappe.db.get_value('CF Prompt', frm.doc.template_prompt, 'content')
+                .then(r => {
+                    if (r.message && r.message.content) {
+                        frm.set_value('ai_prompt', r.message.content);
+                    }
+                });
+        } else {
+            // Clear prompt if template_prompt is cleared
+            frm.set_value('ai_prompt', '');
+        }
     }
 });
 

--- a/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.json
@@ -44,6 +44,7 @@
   "section_break_11",
   "ticker_info_html",
   "ai_tab",
+  "template_prompt",
   "ai_prompt",
   "raw_data_tab",
   "ticker_info_section",
@@ -271,9 +272,8 @@
   },
   {
    "fieldname": "ai_prompt",
-   "fieldtype": "Text",
-   "label": "AI Prompt",
-   "read_only": 1
+   "fieldtype": "Markdown Editor",
+   "label": "AI Prompt"
   },
   {
    "fieldname": "raw_data_tab",
@@ -379,6 +379,12 @@
    "label": "Fair Value",
    "options": "currency",
    "read_only": 1
+  },
+  {
+   "fieldname": "template_prompt",
+   "fieldtype": "Link",
+   "label": "Template Prompt",
+   "options": "CF Prompt"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -400,7 +406,7 @@
    "link_fieldname": "security"
   }
  ],
- "modified": "2025-05-30 18:28:51.396869",
+ "modified": "2025-06-01 09:47:05.130652",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Security",

--- a/cognitive_folio/cognitive_folio/doctype/cf_settings/cf_settings.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_settings/cf_settings.json
@@ -8,7 +8,6 @@
   "open_ai_url",
   "open_ai_api_key",
   "system_content",
-  "user_content",
   "section_break_models",
   "default_ai_model",
   "ai_models"
@@ -47,19 +46,13 @@
    "fieldname": "system_content",
    "fieldtype": "Small Text",
    "label": "System Content"
-  },
-  {
-   "description": "<b>Security</b> - <b>Details:</b> {{security_name}} {{isin}} {{symbol}} <b>Classification:</b> {{country}} {{region}} {{subregion}} {{sector}} {{industry}} <b>Pricing:</b> {{currency}} {{current_price}} {{ticker_info}} <b>Fundamentals:</b> {{profit_loss}} {{balance_sheet}} {{cash_flow}} {{dividends}} <b>News:</b>{{news}} {{news_urls}} <b>Analysis:</b> {{alert_details}} {{suggestion_action}} {{suggestion_rating}} <b>Valuation:</b> {{suggestion_buy_price}} {{suggestion_sell_price}} {{intrinsic_value}} {{fair_value}} <b>Portfolio </b> - ((Target Allocations)) ((portfolio_name)) ((risk_profile)) ((currency)) ((total_value)) ((total_profit_loss)) <b>Holding</b> - [[current_price]] [[current_price_sec]] [[quantity]] [[average_purchase_price]] [[base_average_purchase_price]] [[base_cost]] [[current_value]] [[allocation_percentage]] [[yearly_dividend_income]] [[total_dividend_income]] [[profit_loss_percentage]] [[profit_loss]]",
-   "fieldname": "user_content",
-   "fieldtype": "Markdown Editor",
-   "label": "User Content (Prompt)"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-30 18:36:00.792408",
+ "modified": "2025-06-01 09:40:07.569435",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Settings",


### PR DESCRIPTION
Introduce a new `template_prompt` field in CF Chat Message, CF Portfolio, and CF Security modules. Implement logic to fetch content from CF Prompt when the field is updated. This enhances the functionality by allowing dynamic content retrieval based on user input.