### PR TITLE
Update symbol assignment logic for non-stock securities in CF Security

### DIFF
--- a/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.js
+++ b/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.js
@@ -1,7 +1,7 @@
 frappe.ui.form.on('CF Security', {
     validate: function(frm) {
         // If security type is Cash, set symbol equal to security_name
-        if(frm.doc.security_type === "Cash") {
+        if ((frm.doc.security_type !== "Stock") && !frm.doc.symbol) {
             frm.set_value('symbol', frm.doc.security_name);
         }
     },
@@ -298,7 +298,7 @@ frappe.ui.form.on('CF Security', {
 // Function to search for stocks based on search term
 function search_stocks(frm, search_term) {
 
-    if (frm.doc.security_type == 'Cash') {
+    if (frm.doc.security_type != 'Stock') {
         return;
     }
 

--- a/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.py
@@ -18,9 +18,11 @@ except ImportError:
 
 class CFSecurity(Document):
 	def validate(self):
+
+		if self.security_type != "Stock" and not self.symbol:
+			self.symbol = self.security_name
 			
 		if self.security_type == "Cash":
-			self.symbol = self.security_name
 			self.current_price = 1.0
 
 		if self.security_type == "Stock":


### PR DESCRIPTION
Revise the symbol assignment logic to ensure that non-stock securities receive the correct symbol based on their security name. This change enhances the validation process for CF Security documents.