### PR TITLE
Update field types to Markdown Editor and adjust field order in CF components

### DIFF
--- a/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat/cf_chat.json
@@ -5,12 +5,12 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "model",
   "portfolio",
   "security",
   "title",
   "duplicated_from",
   "column_break_zqji",
-  "model",
   "system_prompt",
   "messages_section",
   "messages"
@@ -49,7 +49,7 @@
   {
    "allow_in_quick_entry": 1,
    "fieldname": "system_prompt",
-   "fieldtype": "Small Text",
+   "fieldtype": "Markdown Editor",
    "label": "System Prompt"
   },
   {
@@ -87,7 +87,7 @@
    "link_fieldname": "chat"
   }
  ],
- "modified": "2025-06-02 09:05:21.773550",
+ "modified": "2025-06-03 10:13:40.426473",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Chat",

--- a/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_chat_message/cf_chat_message.json
@@ -7,8 +7,8 @@
  "field_order": [
   "chat",
   "status",
-  "column_break_cbjh",
   "model",
+  "column_break_cbjh",
   "system_prompt",
   "template_prompt",
   "section_break_nyal",
@@ -95,7 +95,7 @@
    "fetch_from": "chat.system_prompt",
    "fetch_if_empty": 1,
    "fieldname": "system_prompt",
-   "fieldtype": "Small Text",
+   "fieldtype": "Markdown Editor",
    "label": "System Prompt"
   },
   {
@@ -108,7 +108,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-01 09:41:27.986475",
+ "modified": "2025-06-03 10:14:22.669766",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Chat Message",

--- a/cognitive_folio/cognitive_folio/doctype/cf_settings/cf_settings.json
+++ b/cognitive_folio/cognitive_folio/doctype/cf_settings/cf_settings.json
@@ -44,7 +44,7 @@
   },
   {
    "fieldname": "system_content",
-   "fieldtype": "Small Text",
+   "fieldtype": "Markdown Editor",
    "label": "System Content"
   }
  ],
@@ -52,7 +52,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-06-01 09:40:07.569435",
+ "modified": "2025-06-03 10:12:28.786535",
  "modified_by": "Administrator",
  "module": "Cognitive Folio",
  "name": "CF Settings",


### PR DESCRIPTION
Change field types from Small Text to Markdown Editor in CF Chat, CF Chat Message, and CF Settings, while also adjusting the field order for better organization.