### PR TITLE
Fix equality operator in security type filter for portfolio holdings

### DIFF
--- a/cognitive_folio/cognitive_folio/doctype/cf_portfolio/cf_portfolio.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_portfolio/cf_portfolio.py
@@ -65,7 +65,7 @@ class CFPortfolio(Document):
 				"CF Portfolio Holding",
 				filters=[
 					["portfolio", "=", self.name],
-					["security_type", "==", "Stock"]
+					["security_type", "=", "Stock"]
 				],
 				fields=["name", "security", "modified"]
 			)


### PR DESCRIPTION
Correct the equality operator in the security type filter to ensure accurate portfolio holdings retrieval.