### PR TITLE
Add functionality to copy holdings to a target portfolio with validation

### DIFF
--- a/cognitive_folio/public/js/cf_portfolio_holding_list.js
+++ b/cognitive_folio/public/js/cf_portfolio_holding_list.js
@@ -86,6 +86,16 @@ frappe.listview_settings['CF Portfolio Holding'].onload = function(listview) {
                 return;
             }
 
+            // Check if quantity or average_purchase_price are missing
+            const missing_data = selected_docs.filter(doc => 
+                !doc.quantity || !doc.average_purchase_price
+            );
+
+            if (missing_data.length > 0) {
+                frappe.throw(__("Please add quantity and average purchase price in the list view before copying holdings."));
+                return;
+            }
+
             // Show dialog to select target portfolio
             let dialog = new frappe.ui.Dialog({
                 title: __('Copy Holdings to Portfolio'),

--- a/cognitive_folio/public/js/cf_portfolio_holding_list.js
+++ b/cognitive_folio/public/js/cf_portfolio_holding_list.js
@@ -77,5 +77,65 @@ frappe.listview_settings['CF Portfolio Holding'].onload = function(listview) {
                 }
             });
         });
+
+        listview.page.add_action_item(__("Copy to Portfolio"), function() {
+            const selected_docs = listview.get_checked_items();
+
+            if (selected_docs.length === 0) {
+                frappe.throw(__("Please select at least one CF Portfolio Holding"));
+                return;
+            }
+
+            // Show dialog to select target portfolio
+            let dialog = new frappe.ui.Dialog({
+                title: __('Copy Holdings to Portfolio'),
+                fields: [
+                    {
+                        label: __('Target Portfolio'),
+                        fieldname: 'target_portfolio',
+                        fieldtype: 'Link',
+                        options: 'CF Portfolio',
+                        reqd: 1,
+                        description: __('Select the portfolio where you want to copy the selected holdings')
+                    }
+                ],
+                primary_action_label: __('Copy Holdings'),
+                primary_action(values) {
+                    if (!values.target_portfolio) {
+                        frappe.throw(__("Please select a target portfolio"));
+                        return;
+                    }
+
+                    // Prepare holdings data for copying
+                    const holdings_data = selected_docs.map(doc => ({
+                        portfolio: values.target_portfolio,
+                        security: doc.security,
+                        quantity: doc.quantity,
+                        average_purchase_price: doc.average_purchase_price
+                    }));
+
+                    frappe.call({
+                        method: "cognitive_folio.cognitive_folio.doctype.cf_portfolio_holding.cf_portfolio_holding.copy_holdings_to_portfolio",
+                        args: {
+                            holdings_data: holdings_data
+                        },
+                        freeze: true,
+                        freeze_message: __("Copying holdings..."),
+                        callback: function(r) {
+                            if (!r.exc) {
+                                frappe.show_alert({
+                                    message: __('Holdings copied successfully to {0}', [values.target_portfolio]),
+                                    indicator: 'green'
+                                });
+                                dialog.hide();
+                                listview.refresh();
+                            }
+                        }
+                    });
+                }
+            });
+
+            dialog.show();
+        });
     }
 };

--- a/cognitive_folio/public/js/cf_security_list.js
+++ b/cognitive_folio/public/js/cf_security_list.js
@@ -76,5 +76,75 @@ frappe.listview_settings['CF Security'].onload = function(listview) {
                 }
             });
         });
+
+        listview.page.add_action_item(__("Copy to Portfolio"), function() {
+            const selected_docs = listview.get_checked_items();
+
+            if (selected_docs.length === 0) {
+                frappe.throw(__("Please select at least one CF Portfolio Holding"));
+                return;
+            }
+
+            // Check if quantity or average_purchase_price are missing
+            const missing_data = selected_docs.filter(doc => 
+                !doc.current_price
+            );
+
+            if (missing_data.length > 0) {
+                frappe.throw(__("Please add current price in the list view before copying holdings."));
+                return;
+            }
+
+            // Show dialog to select target portfolio
+            let dialog = new frappe.ui.Dialog({
+                title: __('Copy Holdings to Portfolio'),
+                fields: [
+                    {
+                        label: __('Target Portfolio'),
+                        fieldname: 'target_portfolio',
+                        fieldtype: 'Link',
+                        options: 'CF Portfolio',
+                        reqd: 1,
+                        description: __('Select the portfolio where you want to copy the selected holdings')
+                    }
+                ],
+                primary_action_label: __('Copy Holdings'),
+                primary_action(values) {
+                    if (!values.target_portfolio) {
+                        frappe.throw(__("Please select a target portfolio"));
+                        return;
+                    }
+
+                    // Prepare holdings data for copying
+                    const holdings_data = selected_docs.map(doc => ({
+                        portfolio: values.target_portfolio,
+                        security: doc.name,
+                        quantity: 1,
+                        average_purchase_price: doc.current_price
+                    }));
+
+                    frappe.call({
+                        method: "cognitive_folio.cognitive_folio.doctype.cf_portfolio_holding.cf_portfolio_holding.copy_holdings_to_portfolio",
+                        args: {
+                            holdings_data: holdings_data
+                        },
+                        freeze: true,
+                        freeze_message: __("Copying holdings..."),
+                        callback: function(r) {
+                            if (!r.exc) {
+                                frappe.show_alert({
+                                    message: __('Holdings copied successfully to {0}', [values.target_portfolio]),
+                                    indicator: 'green'
+                                });
+                                dialog.hide();
+                                listview.refresh();
+                            }
+                        }
+                    });
+                }
+            });
+
+            dialog.show();
+        });
     }
 };


### PR DESCRIPTION
Introduce a feature to copy holdings to a target portfolio, including validation for quantity and average purchase price. A dialog prompts users to select a target portfolio before executing the copy operation.