### PR TITLE
Disable AI suggestions after document insertion and optimize earnings date extraction

### DIFF
--- a/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.py
@@ -68,6 +68,91 @@ class CFSecurity(Document):
 			if getdate(self.earnings_release) <= getdate(today()):
 				self.need_evaluation = 1
 
+	def _extract_earnings_date_optimized(self, ticker, ticker_info):
+		"""
+		Smart earnings date extraction with minimal API calls.
+		
+		Strategy:
+		1. Check ticker_info first (free, already fetched)
+		2. Call get_earnings_dates() only if no future date exists
+		3. Return formatted date string or None
+		
+		Args:
+			ticker: yfinance.Ticker instance
+			ticker_info: Dictionary from ticker.get_info()
+		
+		Returns:
+			str: Formatted date string ('YYYY-MM-DD') or None if not found
+		"""
+		try:
+			# First, check if we already have a future earnings date stored
+			if self.earnings_release:
+				if getdate(self.earnings_release) > getdate(today()):
+					frappe.log_error(f"Earnings date already cached: {self.earnings_release}", "Earnings Date Debug")
+					return None  # Already have a future date, skip API call
+			
+			# Strategy 1: Check ticker_info first (free, no API call)
+			earnings_date_key = ticker_info.get('earningsDate')
+			if earnings_date_key:
+				try:
+					if isinstance(earnings_date_key, (int, float)):
+						# Unix timestamp
+						from datetime import datetime
+						earnings_dt = datetime.fromtimestamp(earnings_date_key)
+						formatted_date = earnings_dt.strftime('%Y-%m-%d')
+						frappe.log_error(f"Earnings date from ticker_info: {formatted_date}", "Earnings Date Debug")
+						return formatted_date
+					else:
+						frappe.log_error(f"Earnings date from ticker_info: {earnings_date_key}", "Earnings Date Debug")
+						return str(earnings_date_key)
+				except Exception as e:
+					frappe.log_error(f"Error parsing earningsDate from ticker_info: {str(e)}", "Earnings Date Parse Error")
+			
+			# Strategy 2: Check earningsTimestamp as fallback
+			earnings_timestamp = ticker_info.get('earningsTimestamp')
+			if earnings_timestamp:
+				try:
+					if isinstance(earnings_timestamp, (int, float)):
+						from datetime import datetime
+						earnings_dt = datetime.fromtimestamp(earnings_timestamp)
+						formatted_date = earnings_dt.strftime('%Y-%m-%d')
+						frappe.log_error(f"Earnings date from earningsTimestamp: {formatted_date}", "Earnings Date Debug")
+						return formatted_date
+				except Exception as e:
+					frappe.log_error(f"Error parsing earningsTimestamp: {str(e)}", "Earnings Date Parse Error")
+			
+			# Strategy 3: Call get_earnings_dates() only when ticker_info doesn't have the date
+			frappe.log_error(f"Fetching earnings dates via get_earnings_dates() for {self.symbol}", "Earnings Date Debug")
+			try:
+				earnings_df = ticker.get_earnings_dates()
+				if earnings_df is not None and not earnings_df.empty:
+					# Get the first (most recent/upcoming) earnings date
+					first_earnings_date = earnings_df.index[0]
+					formatted_date = first_earnings_date.strftime('%Y-%m-%d')
+					frappe.log_error(f"Earnings date from get_earnings_dates(): {formatted_date}", "Earnings Date Debug")
+					return formatted_date
+			except Exception as e:
+				frappe.log_error(f"Error calling get_earnings_dates(): {str(e)}", "Earnings Dates API Error")
+			
+			# Strategy 4: Fallback to ticker.calendar if available
+			try:
+				if hasattr(ticker, 'calendar') and ticker.calendar:
+					calendar_dict = ticker.calendar
+					if isinstance(calendar_dict, dict) and 'Earnings Date' in calendar_dict:
+						earnings_date = calendar_dict['Earnings Date']
+						formatted_date = str(earnings_date).split()[0]  # Extract just the date part
+						frappe.log_error(f"Earnings date from ticker.calendar: {formatted_date}", "Earnings Date Debug")
+						return formatted_date
+			except Exception as e:
+				frappe.log_error(f"Error accessing ticker.calendar: {str(e)}", "Ticker Calendar Error")
+			
+			frappe.log_error(f"No earnings date found for {self.symbol}", "Earnings Date Debug")
+			return None
+			
+		except Exception as e:
+			frappe.log_error(f"Error in _extract_earnings_date_optimized for {self.symbol}: {str(e)}", "Earnings Date Extraction Error")
+			return None
+
 	def on_change(self):
 		"""Save all holdings"""
 		holdings = frappe.get_all(
@@ -148,6 +233,11 @@ class CFSecurity(Document):
 			self.news = frappe.as_json(ticker.get_news())
 			self.news_urls = "\n".join([item['content']['clickThroughUrl']['url'] for item in json.loads(self.news) if item.get('content') and item['content'].get('clickThroughUrl') and item['content']['clickThroughUrl'].get('url')])
 			self.country = ticker_info.get('country', '')
+			
+			# Extract and set earnings release date with optimized caching
+			earnings_date = self._extract_earnings_date_optimized(ticker, ticker_info)
+			if earnings_date:
+				self.earnings_release = earnings_date
 			if with_fundamentals:
 				if not self.cik:
 					self.fetch_cik()

--- a/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.py
+++ b/cognitive_folio/cognitive_folio/doctype/cf_security/cf_security.py
@@ -127,7 +127,7 @@ class CFSecurity(Document):
 		"""Fetch and set the current price after inserting the document"""
 		if YFINANCE_INSTALLED:
 			self.fetch_data(with_fundamentals=True)
-			self.generate_ai_suggestion()
+			#self.generate_ai_suggestion()
 	
 	@frappe.whitelist()
 	def fetch_data(self, with_fundamentals=False):


### PR DESCRIPTION
Disable AI suggestion generation upon document insertion to improve performance. Implement an optimized earnings date extraction method that utilizes caching and fallback strategies to minimize API calls.